### PR TITLE
Allow both male and female Ratkins for the Vagabond joins event

### DIFF
--- a/1.0/Defs/Storytellers/Storytellers.xml
+++ b/1.0/Defs/Storytellers/Storytellers.xml
@@ -135,7 +135,6 @@
 		<minRefireDays>60</minRefireDays>
 		<minGreatestPopulation>3</minGreatestPopulation>
 		<pawnKind>RatkinVagabond</pawnKind>
-		<pawnFixedGender>Male</pawnFixedGender>
 		<pawnMustBeCapableOfViolence>true</pawnMustBeCapableOfViolence>
 	</IncidentDef>
 </Defs>

--- a/1.1/Defs/Storytellers/Storytellers.xml
+++ b/1.1/Defs/Storytellers/Storytellers.xml
@@ -158,7 +158,6 @@
 		<minRefireDays>60</minRefireDays>
 		<minGreatestPopulation>3</minGreatestPopulation>
 		<pawnKind>RatkinVagabond</pawnKind>
-		<pawnFixedGender>Male</pawnFixedGender>
 		<pawnMustBeCapableOfViolence>true</pawnMustBeCapableOfViolence>
 	</IncidentDef>
 </Defs>

--- a/1.2/Defs/Storytellers/Storytellers.xml
+++ b/1.2/Defs/Storytellers/Storytellers.xml
@@ -158,7 +158,6 @@
 		<minRefireDays>60</minRefireDays>
 		<minGreatestPopulation>3</minGreatestPopulation>
 		<pawnKind>RatkinVagabond</pawnKind>
-		<pawnFixedGender>Male</pawnFixedGender>
 		<pawnMustBeCapableOfViolence>true</pawnMustBeCapableOfViolence>
 	</IncidentDef>
 </Defs>


### PR DESCRIPTION
At present, the Ratkin Vagabond join event will only spawn male Ratkins.

However, according to the `AlienRace.ThingDef_AlienRace` definition for the Ratkin race, `maleGenderProbability` is 0.1, meaning there are 9 Ratkin females for every 1 Ratkin male. This means that there should be a higher chance of getting a female Ratkin vagabond than a male.

I would like to suggest removing the `pawnFixedGender` setting from the `RatkinVagabondJoin` incident, to allow Ratkins of both genders to join a player colony.