### PR TITLE
Add new and tweak existing backstories

### DIFF
--- a/1.2/Defs/BackStoryDefs/BackstoryDef.xml
+++ b/1.2/Defs/BackStoryDefs/BackstoryDef.xml
@@ -93,6 +93,12 @@
 				<amount>3</amount>
 			</li>
 		</skillGains>
+		<forcedTraits>
+			<li>
+				<defName>Undergrounder</defName>
+				<chance>50</chance>
+			</li>
+		</forcedTraits>
 		<spawnCategories>
 			<li>RatkinStory</li>
 			<li>RatkinSubject</li>
@@ -147,7 +153,9 @@
 	<AlienRace.BackstoryDef ParentName="BaseRatkinBackStory">
 		<defName>Ratkin_ShepherdBoy</defName>
 		<title>Ratkin shepherd boy</title>
+		<titleFemale>Ratkin shepherd girl</titleFemale>
 		<titleShort>shepherd boy</titleShort>
+		<titleShortFemale>shepherd girl</titleShortFemale>
 		<baseDescription>[PAWN_nameDef]은 어려서부터 다양한 가축들 사이에서 자랐습니다. [PAWN_pronoun]은 동물들을 친구처럼 생각하고 있습니다.</baseDescription>
 		<bodyTypeMale>Thin</bodyTypeMale>
 		<bodyTypeFemale>Thin</bodyTypeFemale>
@@ -412,8 +420,10 @@
 	<!-- 후계자 -->
 	<AlienRace.BackstoryDef ParentName="BaseRatkinBackStory">
 		<defName>Ratkin_Successor</defName>
-		<title>Ratkin successor</title>
-		<titleShort>successor</titleShort>
+		<title>Ratkin heir</title>
+		<titleFemale>Ratkin heiress</titleFemale>
+		<titleShort>Heir</titleShort>
+		<titleShortFemale>Heiress</titleShortFemale>
 		<baseDescription>[PAWN_nameDef]은 귀족의 후계자로 태어났습니다. 한때 찬란했던 가문이 기울자 [PAWN_pronoun]은 일으키기 위해 길을 떠나야만 했습니다.</baseDescription>
 		<bodyTypeMale>Thin</bodyTypeMale>
 		<bodyTypeFemale>Thin</bodyTypeFemale>
@@ -515,7 +525,62 @@
 			<li>RatkinServant</li>
 			<li>RatkinEducated</li>
 		</spawnCategories>
-	</AlienRace.BackstoryDef>	
+	</AlienRace.BackstoryDef>
+		<!-- 견습 재봉사 Apprentice seamstress -->
+	<AlienRace.BackstoryDef ParentName="BaseRatkinBackStory">
+		<defName>Ratkin_SeamstressStudent</defName>
+		<title>Ratkin Apprentice seamstress</title>
+		<titleShort>Apprentice seamstress</titleShort>
+		<baseDescription>(Needs Korean translation) As the apprentice of a master dressmaker, [PAWN_nameDef] spun thread, tidied rolls of fabric and swept the shop floor clean.\n\nIn time, [PAWN_pronoun] was also entrusted with sewing buttons, handkerchiefs and other small, simple items.</baseDescription>
+		<bodyTypeMale>Thin</bodyTypeMale>
+		<bodyTypeFemale>Thin</bodyTypeFemale>
+		<maleCommonality>0</maleCommonality>
+		<!-- Females only -->
+		<slot>Childhood</slot>
+		<skillGains>
+			<li>
+				<defName>Crafting</defName>
+				<amount>2</amount>
+			</li>
+		</skillGains>
+		<workDisables>
+			<li>Mining</li>
+		</workDisables>
+		<spawnCategories>
+			<li>RatkinStory</li>
+			<li>RatkinServant</li>
+			<li>RatkinCity</li> <!-- Unused -->
+		</spawnCategories>
+		<linkedBackstory>Ratkin_Seamstress</linkedBackstory>
+	</AlienRace.BackstoryDef>
+	<!-- 향사 Squire (apprentice knight) -->
+	<AlienRace.BackstoryDef ParentName="BaseRatkinBackStory">
+		<defName>Ratkin_KnightStudent</defName>
+		<title>Ratkin squire</title>
+		<titleShort>Squire</titleShort>
+		<baseDescription>(Needs Korean translation) [PAWN_nameDef] left [PAWN_possessive] home village after becoming apprenticed to a knight of the Ratkin Kingdom.\n\n[PAWN_pronoun] spent his days cleaning [PAWN_possessive] master's armor and weapons, as well as looking after [PAWN_possessive] master's king hamster mount. In return, [PAWN_possessive] master trained [PAWN_objective] in basic swordsmanship.</baseDescription>
+		<bodyTypeMale>Thin</bodyTypeMale>
+		<bodyTypeFemale>Thin</bodyTypeFemale>
+		<slot>Childhood</slot>
+		<skillGains>
+			<li>
+				<defName>Melee</defName>
+				<amount>4</amount>
+			</li>
+			<li>
+				<defName>Animals</defName>
+				<amount>2</amount>
+			</li>
+			<li>
+				<defName>Crafting</defName>
+				<amount>2</amount>
+			</li>
+		</skillGains>
+		<spawnCategories>
+			<li>RatkinKnight</li>
+			<li>RatkinKnightCommander</li>
+		</spawnCategories>
+	</AlienRace.BackstoryDef>
 	<!-- 집시아이 -->
 	<AlienRace.BackstoryDef ParentName="BaseRatkinBackStory">
 		<defName>Ratkin_RomanyKid</defName>
@@ -1067,6 +1132,40 @@
 			<li>RatkinCity</li>
 			<li>RatkinDefender</li>
 		</spawnCategories>
+		<linkedBackstory>Ratkin_CountryKid</linkedBackstory>
+	</AlienRace.BackstoryDef>
+	<!-- Farmhand -->
+	<AlienRace.BackstoryDef ParentName="BaseRatkinBackStory">
+		<defName>Ratkin_FarmLaborer</defName>
+		<title>Ratkin farmhand</title>
+		<titleShort>Farmhand</titleShort>
+		<baseDescription>(Needs Korean translation) [PAWN_nameDef] worked as a laborer on various farms in the countryside, ploughing the fields, mending fences and caring for farm animals, as well as sowing and harvesting crops.\n\nWhenever work dried up, [PAWN_pronoun] would move on to a different village.</baseDescription>
+		<bodyTypeMale>Thin</bodyTypeMale>
+		<bodyTypeFemale>Thin</bodyTypeFemale>
+		<slot>Adulthood</slot>
+		<skillGains>
+			<li>
+				<defName>Animals</defName>
+				<amount>1</amount>
+			</li>
+			<li>
+				<defName>Construction</defName>
+				<amount>2</amount>
+			</li>
+			<li>
+				<defName>Plants</defName>
+				<amount>8</amount>
+			</li>
+		</skillGains>
+		<workDisables>
+			<li>Intellectual</li>
+		</workDisables>
+		<spawnCategories>
+			<li>RatkinStory</li>
+			<li>RatkinUneducated</li>
+			<li>RatkinCountry</li>
+			<li>RatkinWanderer</li>
+		</spawnCategories>
 	</AlienRace.BackstoryDef>
 	<!-- 광부 -->
 	<AlienRace.BackstoryDef ParentName="BaseRatkinBackStory">
@@ -1323,6 +1422,49 @@
 				<chance>50</chance>
 			</li>
 		</forcedTraits>
+	</AlienRace.BackstoryDef>
+	<!-- Guardener (B) -->
+	<AlienRace.BackstoryDef ParentName="BaseRatkinBackStory">
+		<defName>Ratkin_GuardenerB</defName>
+		<title>Ratkin Guardener</title>
+		<titleShort>Guardener</titleShort>
+		<baseDescription>(Needs Korean translation) [PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\n[PAWN_pronoun] fought in the Battle of Whitefur's Keep, where [PAWN_pronoun] was part of the successful counterattack that decisively defeated invaders from the Grimalkin Dominion.</baseDescription>
+		<!-- Battle of Whitefur's Keep = 흰털의 아성 전투 -->
+		<bodyTypeMale>Thin</bodyTypeMale>
+		<bodyTypeFemale>Thin</bodyTypeFemale>
+		<slot>Adulthood</slot>
+		<skillGains>
+			<li>
+				<defName>Shooting</defName>
+				<amount>8</amount>
+			</li>
+			<li>
+				<defName>Melee</defName>
+				<amount>12</amount>
+			</li>
+			<li>
+				<defName>Plants</defName>
+				<amount>5</amount>
+			</li>
+		</skillGains>
+		<spawnCategories>
+			<li>RatkinStory</li>
+			<li>RatkinEducated</li>
+			<li>RatkinCombatant</li>
+			<li>RatkinKnight</li>
+			<li>RatkinSoldier</li>
+			<li>RatkinEliteDefender</li>
+			<li>RatkinDefender</li>
+			<li>RatkinGuardener</li>
+			<li>RatkinKingdom</li>
+		</spawnCategories>
+		<forcedTraits>
+			<li>
+				<defName>Nimble</defName>
+				<chance>50</chance>
+			</li>
+		</forcedTraits>
+		<linkedBackstory>Ratkin_GuardenerStudent</linkedBackstory>
 	</AlienRace.BackstoryDef>
 
 	<!-- 기사 -->
@@ -2232,6 +2374,40 @@
 			<li>RatkinSubject</li>
 			<li>RatkinCity</li>
 		</spawnCategories>
+	</AlienRace.BackstoryDef>
+	<!-- Seamstress -->
+	<AlienRace.BackstoryDef ParentName="BaseRatkinBackStory">
+		<defName>Ratkin_Seamstress</defName>
+		<title>Ratkin seamstress</title>
+		<titleShort>Seamstress</titleShort>
+		<baseDescription>(Needs Korean translation) [PAWN_nameDef] became good at making a variety of clothes, ranging from simple workers' dresses to elaborate formal outfits. Many Ratkin nobles often travelled all the way to [PAWN_possessive] humble workshop to commission apparel for special occasions.\n\n[PAWN_possessive] own apprentice later went on to become a successful seamstress in her own right.</baseDescription>
+		<bodyTypeMale>Thin</bodyTypeMale>
+		<bodyTypeFemale>Thin</bodyTypeFemale>
+		<maleCommonality>0</maleCommonality>
+		<!-- Females only -->
+		<slot>Adulthood</slot>
+		<bioAgeRange>
+			<min>30</min>
+			<max>65</max>
+		</bioAgeRange>
+		<chronoAgeRange>
+			<min>30</min>
+			<max>65</max>
+		</chronoAgeRange>
+		<skillGains>
+			<li>
+				<defName>Crafting</defName>
+				<amount>6</amount>
+			</li>
+		</skillGains>
+		<workDisables>
+			<li>Mining</li>
+		</workDisables>
+		<spawnCategories>
+			<li>RatkinStory</li>
+			<li>RatkinServant</li>
+		</spawnCategories>
+		<linkedBackstory>Ratkin_SeamstressStudent</linkedBackstory>
 	</AlienRace.BackstoryDef>
 
 	<!-- 방랑자 -->

--- a/1.2/Defs/BackStoryDefs/BackstoryDef.xml
+++ b/1.2/Defs/BackStoryDefs/BackstoryDef.xml
@@ -1164,7 +1164,7 @@
 			<li>RatkinStory</li>
 			<li>RatkinUneducated</li>
 			<li>RatkinCountry</li>
-			<li>RatkinWanderer</li>
+			<li>RatkinDefender</li>
 		</spawnCategories>
 	</AlienRace.BackstoryDef>
 	<!-- 광부 -->
@@ -1464,7 +1464,6 @@
 				<chance>50</chance>
 			</li>
 		</forcedTraits>
-		<linkedBackstory>Ratkin_GuardenerStudent</linkedBackstory>
 	</AlienRace.BackstoryDef>
 
 	<!-- 기사 -->

--- a/Languages/English/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
+++ b/Languages/English/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
@@ -103,7 +103,7 @@
 
 	<Ratkin_KnightStudent.title>Ratkin squire</Ratkin_KnightStudent.title>
 	<Ratkin_KnightStudent.titleShort>Squire</Ratkin_KnightStudent.titleShort>
-	<Ratkin_KnightStudent.baseDescription>A[PAWN_nameDef] left [PAWN_possessive] home village after becoming apprenticed to a knight of the Ratkin Kingdom.\n\n[PAWN_pronoun] spent his days cleaning [PAWN_possessive] master's armor and weapons, as well as looking after [PAWN_possessive] master's king hamster mount. In return, [PAWN_possessive] master trained [PAWN_objective] in basic swordsmanship.</Ratkin_KnightStudent.baseDescription>
+	<Ratkin_KnightStudent.baseDescription>[PAWN_nameDef] left [PAWN_possessive] home village after becoming apprenticed to a knight of the Ratkin Kingdom.\n\n[PAWN_pronoun] spent [PAWN_possessive] days cleaning [PAWN_possessive] master's armor and weapons, as well as looking after [PAWN_possessive] master's king hamster mount. In return, [PAWN_possessive] master trained [PAWN_objective] in basic swordsmanship.</Ratkin_KnightStudent.baseDescription>
 
 
 	<!-- 집시아이 -->

--- a/Languages/English/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
+++ b/Languages/English/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
@@ -25,7 +25,9 @@
 	<!-- 꼬마목동 -->
 
 	<Ratkin_ShepherdBoy.title>Ratkin shepherd boy</Ratkin_ShepherdBoy.title>
+	<Ratkin_ShepherdBoy.titleFemale>Ratkin shepherd girl</Ratkin_ShepherdBoy.titleFemale>
 	<Ratkin_ShepherdBoy.titleShort>Shepherd boy</Ratkin_ShepherdBoy.titleShort>
+	<Ratkin_ShepherdBoy.titleShortFemale>shepherd girl</Ratkin_ShepherdBoy.titleShortFemale>
 	<Ratkin_ShepherdBoy.baseDescription>[PAWN_nameDef] grew up alongside animals, and came to regard them as friends.</Ratkin_ShepherdBoy.baseDescription>
 
 
@@ -69,8 +71,10 @@
 
 	<!-- 후계자 -->
 
-	<Ratkin_Successor.title>Ratkin successor</Ratkin_Successor.title>
-	<Ratkin_Successor.titleShort>Successor</Ratkin_Successor.titleShort>
+	<Ratkin_Successor.title>Ratkin heir</Ratkin_Successor.title>
+	<Ratkin_Successor.titleFemale>Ratkin heiress</Ratkin_Successor.titleFemale>
+	<Ratkin_Successor.titleShort>Heir</Ratkin_Successor.titleShort>
+	<Ratkin_Successor.titleShortFemale>Heiress</Ratkin_Successor.titleShortFemale>
 	<Ratkin_Successor.baseDescription>[PAWN_nameDef] was the heir of a noble family.\n\nAfter the clan fell on hard times, [PAWN_pronoun] left home to try and restore [PAWN_possessive] family's fortunes.</Ratkin_Successor.baseDescription>
 
 
@@ -86,6 +90,20 @@
 	<Ratkin_ChefStudent.title>Ratkin apprentice chef</Ratkin_ChefStudent.title>
 	<Ratkin_ChefStudent.titleShort>Apprentice chef</Ratkin_ChefStudent.titleShort>
 	<Ratkin_ChefStudent.baseDescription>[PAWN_nameDef] is a gourmand who learned to cook from a young age to satiate [PAWN_possessive] appetite.\n\nFor [PAWN_objective], food is the ultimate expression of life and enjoyment, so [PAWN_pronoun] often set out on adventures in search of ever-more exquisite delicacies.</Ratkin_ChefStudent.baseDescription>
+	
+	
+	<!-- 견습 재봉사 Apprentice seamstress -->
+
+	<Ratkin_SeamstressStudent.title>Ratkin apprentice seamstress</Ratkin_SeamstressStudent.title>
+	<Ratkin_SeamstressStudent.titleShort>Apprentice seamstress</Ratkin_SeamstressStudent.titleShort>
+	<Ratkin_SeamstressStudent.baseDescription>As the apprentice of a master dressmaker, [PAWN_nameDef] spun thread, tidied rolls of fabric and swept the shop floor clean.\n\nIn time, [PAWN_pronoun] was also entrusted with sewing buttons, handkerchiefs and other small, simple items.</Ratkin_SeamstressStudent.baseDescription>
+
+
+	<!-- 향사 Squire (apprentice knight) -->
+
+	<Ratkin_KnightStudent.title>Ratkin squire</Ratkin_KnightStudent.title>
+	<Ratkin_KnightStudent.titleShort>Squire</Ratkin_KnightStudent.titleShort>
+	<Ratkin_KnightStudent.baseDescription>A[PAWN_nameDef] left [PAWN_possessive] home village after becoming apprenticed to a knight of the Ratkin Kingdom.\n\n[PAWN_pronoun] spent his days cleaning [PAWN_possessive] master's armor and weapons, as well as looking after [PAWN_possessive] master's king hamster mount. In return, [PAWN_possessive] master trained [PAWN_objective] in basic swordsmanship.</Ratkin_KnightStudent.baseDescription>
 
 
 	<!-- 집시아이 -->
@@ -177,6 +195,13 @@
 	<Ratkin_Farmer.title>Ratkin farmer</Ratkin_Farmer.title>
 	<Ratkin_Farmer.titleShort>Farmer</Ratkin_Farmer.titleShort>
 	<Ratkin_Farmer.baseDescription>[PAWN_nameDef] is a farmer, having inherited the family farm from [PAWN_possessive] parents, and [PAWN_possessive] children are also destined to become farmers themselves.</Ratkin_Farmer.baseDescription>
+	
+	
+	<!-- 농장 노동자 Farmhand  -->
+
+	<Ratkin_FarmLaborer.title>Ratkin farmhand</Ratkin_FarmLaborer.title>
+	<Ratkin_FarmLaborer.titleShort>Farmhand</Ratkin_FarmLaborer.titleShort>
+	<Ratkin_FarmLaborer.baseDescription>[PAWN_nameDef] worked as a laborer on various farms in the countryside, ploughing the fields, mending fences and caring for farm animals, as well as sowing and harvesting crops.\n\nWhenever work dried up, [PAWN_pronoun] would move on to a different village.</Ratkin_FarmLaborer.baseDescription>
 
 
 	<!-- 광부 -->
@@ -233,6 +258,13 @@
 	<Ratkin_Guardener.title>Ratkin Guardener</Ratkin_Guardener.title>
 	<Ratkin_Guardener.titleShort>Guardener</Ratkin_Guardener.titleShort>
 	<Ratkin_Guardener.baseDescription>[PAWN_nameDef] was a Senior Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies. However, [PAWN_pronoun] was exiled after deserting [PAWN_possessive] post during the Kingdom's greatest hour of need.\n\n[PAWN_nameDef] now seeks a way to return to [PAWN_possessive] homeland.</Ratkin_Guardener.baseDescription>
+
+
+	<!-- 정원사 (B) -->
+
+	<Ratkin_GuardenerB.title>Ratkin Guardener</Ratkin_GuardenerB.title>
+	<Ratkin_GuardenerB.titleShort>Guardener</Ratkin_GuardenerB.titleShort>
+	<Ratkin_GuardenerB.baseDescription>[PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\n[PAWN_pronoun] fought in the Battle of Whitefur's Keep, where [PAWN_pronoun] was part of the successful counterattack that decisively defeated invaders from the Grimalkin Dominion.</Ratkin_GuardenerB.baseDescription>
 
 
 	<!-- 기사 -->
@@ -415,6 +447,13 @@
 	<Ratkin_Subject.title>Ratkin test subject</Ratkin_Subject.title>
 	<Ratkin_Subject.titleShort>Test subject</Ratkin_Subject.titleShort>
 	<Ratkin_Subject.baseDescription>[PAWN_nameDef] was used as a biological test specimen for various experiments, which resulted in a number of physical enhancements.\n\nAfter a laboratory accident, [PAWN_pronoun] barely managed to escape.</Ratkin_Subject.baseDescription>
+	
+	
+	<!-- 침모 Seamstress -->
+
+	<Ratkin_Seamstress.title>Ratkin seamstress</Ratkin_Seamstress.title>
+	<Ratkin_Seamstress.titleShort>Seamstress</Ratkin_Seamstress.titleShort>
+	<Ratkin_Seamstress.baseDescription>[PAWN_nameDef] became good at making a variety of clothes, ranging from simple workers' dresses to elaborate formal outfits. Many Ratkin nobles often travelled all the way to [PAWN_possessive] humble workshop to commission apparel for special occasions.\n\n[PAWN_possessive] own apprentice later went on to become a successful seamstress in her own right.</Ratkin_Seamstress.baseDescription>
 
 
 	<!-- 방랑자 -->

--- a/Languages/English/DefInjected/FactionDef/Factions_Misc.xml
+++ b/Languages/English/DefInjected/FactionDef/Factions_Misc.xml
@@ -4,6 +4,6 @@
 	<Rakinia.label>Ratkin Kingdom</Rakinia.label>
 	<Rakinia.description>A monarchical society of Ratkins based on agriculture, with a late-medieval to early-industrial level of technology. Ratkin settlements are typically well-hidden from human eyes.</Rakinia.description>
 	<Rakinia.pawnsPlural>Ratkins</Rakinia.pawnsPlural>
-	<Rakinia.leaderTitle>Prime Excuter</Rakinia.leaderTitle>
+	<Rakinia.leaderTitle>Prime Executor</Rakinia.leaderTitle>
 	
 </LanguageData>


### PR DESCRIPTION
## Additions

* Add the following new backstories:
  * Childhoods 
    * Ratkin apprentice seamstress ("seamstress student")
    * Ratkin squire ("knight student")
  * Adulthood
    * Ratkin farmhand (farmer works on other farmers' farms)
    * Ratkin Guardener "B" version (with alternative heroic non-exile backstory)
    * Ratkin seamstress (always linked to "seamstress student")

## Changes

* Ratkin cave child ("land rat") now has a 50% chance of spawning with Undergrounder trait
* Ratkin shepherd boy now has "shepherd girl" alternative title, depending on pawn gender
* Ratkin successor now has "heir" or "heiress" alternative titles, depending on pawn gender
* Ratkin knights and knight commander has a chance to spawn with squire childhood
* Fix spelling of "Prime Executor" for Ratkin faction leader

## Reasoning/Explanation

* Adds more flavor and variety to existing Ratkin backstories
* Not all Guardeners are deserters, like for the original backstory - some are heroes
* Some farmers are too poor to have their own farms, and work on other people's farms instead