### PR TITLE
Translation fixes (22 Mar 2021)

### DIFF
--- a/Languages/ChineseSimplified/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
+++ b/Languages/ChineseSimplified/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
@@ -350,24 +350,24 @@
 	<Ratkin_Librarian.baseDescription>[PAWN_nameDef]是一个图书管理员。[PAWN_pronoun]具备很多的学术知识，但似乎与书本相处的太久，其他的技能都荒废了。</Ratkin_Librarian.baseDescription>
 
 
-	<!-- EN: Ratkin Guardener -->
-	<Ratkin_Guardener.title>鼠族庄园守卫</Ratkin_Guardener.title>
+	<!-- EN: Lost Ratkin Guardener -->
+	<Ratkin_Guardener.title>迷路的鼠族庄园守卫</Ratkin_Guardener.title>
 	
 	<!-- EN: Guardener -->
 	<Ratkin_Guardener.titleShort>庄园守卫</Ratkin_Guardener.titleShort>
 	
-	<!-- EN: [PAWN_nameDef] was a Senior Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies. However, [PAWN_pronoun] was exiled after deserting [PAWN_possessive] post during the Kingdom's greatest hour of need.\n\n[PAWN_nameDef] now seeks a way to return to [PAWN_possessive] homeland. -->
-	<Ratkin_Guardener.baseDescription>[PAWN_nameDef]是一名高级庄园守卫者。但在[PAWN_pronoun]值班期间擅自离开了自己的岗位而遭到流放。现在[PAWN_pronoun]希望找到能够重归王国的办法。</Ratkin_Guardener.baseDescription>
+	<!-- EN: [PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\nWhile on a mission outside the city walls, [PAWN_pronoun] was accidentally left behind in the confusion of battle, and is now trying to find [PAWN_possessive] way home. -->
+	<Ratkin_Guardener.baseDescription>[PAWN_nameDef]是一名庄园守卫者。在城外执行任务的时候，[PAWN_pronoun]在战斗的混乱中落伍了。现在[PAWN_pronoun]希望找到回家的路。</Ratkin_Guardener.baseDescription>
 	
 	
-	<!-- EN: Ratkin Guardener -->
-	<Ratkin_GuardenerB.title>鼠族庄园守卫</Ratkin_GuardenerB.title>
+	<!-- EN: Guardian of the Kingdom -->
+	<Ratkin_GuardenerB.title>鼠族王国之英雄</Ratkin_GuardenerB.title>
 	
 	<!-- EN: Guardener -->
 	<Ratkin_GuardenerB.titleShort>庄园守卫</Ratkin_GuardenerB.titleShort>
 	
-	<!-- EN: [PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\n[PAWN_pronoun] fought in the Battle of Whitefur's Keep, where [PAWN_pronoun] was part of the successful counterattack that decisively defeated invaders from the Grimalkin Dominion. -->
-	<Ratkin_GuardenerB.baseDescription>[PAWN_nameDef]是一名庄园守卫者，在白毛城战役中击败了入侵的猫族帝国军队，立下赫赫战功。</Ratkin_GuardenerB.baseDescription>
+	<!-- EN: [PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\n[PAWN_pronoun] fought in the Battle of Whitefur's Keep, where [PAWN_pronoun] was part of the successful counterattack that decisively defeated invaders from the Grimalkin Dominion. For their gallantry, [PAWN_pronoun] and [PAWN_possessive] comrades were personally awarded with the title of Guardian of the Kingdom by the Ratkin King himself. -->
+	<Ratkin_GuardenerB.baseDescription>[PAWN_nameDef]是一名庄园守卫者，在白毛城战役中击败了入侵的猫族帝国军队，立下赫赫战功。[PAWN_pronoun]和[PAWN_possessive]的战友因其勇敢而被鼠族国王亲自颁发了《王国的守护者》的称号。</Ratkin_GuardenerB.baseDescription>
 
 
 	<!-- EN: Ratkin knight -->

--- a/Languages/ChineseTraditional/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
+++ b/Languages/ChineseTraditional/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 
 	<!-- EN: Ratkin wild child -->
@@ -351,24 +351,24 @@
 	<Ratkin_Librarian.baseDescription>[PAWN_nameDef]是一個圖書管理員。[PAWN_pronoun]具備很多的學術知識，但似乎與書本相處的太久，其他的技能都荒廢了。</Ratkin_Librarian.baseDescription>
 
 
-	<!-- EN: Ratkin Guardener -->
-	<Ratkin_Guardener.title>鼠族莊園守衛</Ratkin_Guardener.title>
+	<!-- EN: Lost Ratkin Guardener -->
+	<Ratkin_Guardener.title>迷路的鼠族莊園守衛</Ratkin_Guardener.title>
 	
 	<!-- EN: Guardener -->
 	<Ratkin_Guardener.titleShort>莊園守衛</Ratkin_Guardener.titleShort>
 	
-	<!-- EN: [PAWN_nameDef] was a Senior Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies. However, [PAWN_pronoun] was exiled after deserting [PAWN_possessive] post during the Kingdom's greatest hour of need.\n\n[PAWN_nameDef] now seeks a way to return to [PAWN_possessive] homeland. -->
-	<Ratkin_Guardener.baseDescription>[PAWN_nameDef]是一名高級莊園守衛者。但在[PAWN_pronoun]值班期間擅自離開了自己的崗位而遭到流放。現在[PAWN_pronoun]希望找到能夠重歸王國的辦法。</Ratkin_Guardener.baseDescription>
+	<!-- EN: [PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\nWhile on a mission outside the city walls, [PAWN_pronoun] was accidentally left behind in the confusion of battle, and is now trying to find [PAWN_possessive] way home. -->
+	<Ratkin_Guardener.baseDescription>[PAWN_nameDef]是一名莊園守衛者。在城外執行任務的時候，[PAWN_pronoun]在戰鬥的混亂中落伍了。現在[PAWN_pronoun]希望找到回家的路。</Ratkin_Guardener.baseDescription>
 	
 	
-	<!-- EN: Ratkin Guardener -->
-	<Ratkin_GuardenerB.title>鼠族莊園守衛</Ratkin_GuardenerB.title>
+	<!-- EN: Guardian of the Kingdom -->
+	<Ratkin_GuardenerB.title>鼠族王國之英雄</Ratkin_GuardenerB.title>
 	
 	<!-- EN: Guardener -->
 	<Ratkin_GuardenerB.titleShort>莊園守衛</Ratkin_GuardenerB.titleShort>
 	
-	<!-- EN: [PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\n[PAWN_pronoun] fought in the Battle of Whitefur's Keep, where [PAWN_pronoun] was part of the successful counterattack that decisively defeated invaders from the Grimalkin Dominion. -->
-	<Ratkin_GuardenerB.baseDescription>[PAWN_nameDef]是一名莊園守衛者，在白毛城戰役中擊敗了入侵的猫族帝国軍隊，立下赫赫戰功。</Ratkin_GuardenerB.baseDescription>
+	<!-- EN: [PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\n[PAWN_pronoun] fought in the Battle of Whitefur's Keep, where [PAWN_pronoun] was part of the successful counterattack that decisively defeated invaders from the Grimalkin Dominion. For their gallantry, [PAWN_pronoun] and [PAWN_possessive] comrades were personally awarded with the title of Guardian of the Kingdom by the Ratkin King himself. -->
+	<Ratkin_GuardenerB.baseDescription>[PAWN_nameDef]是一名莊園守衛者，在白毛城戰役中擊敗了入侵的猫族帝国軍隊，立下赫赫戰功。[PAWN_pronoun]和[PAWN_possessive]的戰友因其勇敢而被鼠族國王親自頒發了《王國的守護者》的稱號。</Ratkin_GuardenerB.baseDescription>
 
 
 	<!-- EN: Ratkin knight -->

--- a/Languages/English/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
+++ b/Languages/English/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
@@ -255,16 +255,16 @@
 
 	<!-- 정원사 -->
 
-	<Ratkin_Guardener.title>Ratkin Guardener</Ratkin_Guardener.title>
+	<Ratkin_Guardener.title>Lost Ratkin Guardener</Ratkin_Guardener.title>
 	<Ratkin_Guardener.titleShort>Guardener</Ratkin_Guardener.titleShort>
-	<Ratkin_Guardener.baseDescription>[PAWN_nameDef] was a Senior Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies. However, [PAWN_pronoun] was exiled after deserting [PAWN_possessive] post during the Kingdom's greatest hour of need.\n\n[PAWN_nameDef] now seeks a way to return to [PAWN_possessive] homeland.</Ratkin_Guardener.baseDescription>
+	<Ratkin_Guardener.baseDescription>[PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\nWhile on a mission outside the city walls, [PAWN_pronoun] was accidentally left behind in the confusion of battle, and is now trying to find [PAWN_possessive] way home.</Ratkin_Guardener.baseDescription>
 
 
 	<!-- 정원사 (B) -->
 
-	<Ratkin_GuardenerB.title>Ratkin Guardener</Ratkin_GuardenerB.title>
+	<Ratkin_GuardenerB.title>Guardian of the Kingdom</Ratkin_GuardenerB.title>
 	<Ratkin_GuardenerB.titleShort>Guardener</Ratkin_GuardenerB.titleShort>
-	<Ratkin_GuardenerB.baseDescription>[PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\n[PAWN_pronoun] fought in the Battle of Whitefur's Keep, where [PAWN_pronoun] was part of the successful counterattack that decisively defeated invaders from the Grimalkin Dominion.</Ratkin_GuardenerB.baseDescription>
+	<Ratkin_GuardenerB.baseDescription>[PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\n[PAWN_pronoun] fought in the Battle of Whitefur's Keep, where [PAWN_pronoun] was part of the successful counterattack that decisively defeated invaders from the Grimalkin Dominion. For their gallantry, [PAWN_pronoun] and her comrades were personally awarded with the title of Guardian of the Kingdom by the Ratkin King himself.</Ratkin_GuardenerB.baseDescription>
 
 
 	<!-- 기사 -->

--- a/Languages/English/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
+++ b/Languages/English/DefInjected/AlienRace.BackstoryDef/BackstoryDef.xml
@@ -264,7 +264,7 @@
 
 	<Ratkin_GuardenerB.title>Guardian of the Kingdom</Ratkin_GuardenerB.title>
 	<Ratkin_GuardenerB.titleShort>Guardener</Ratkin_GuardenerB.titleShort>
-	<Ratkin_GuardenerB.baseDescription>[PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\n[PAWN_pronoun] fought in the Battle of Whitefur's Keep, where [PAWN_pronoun] was part of the successful counterattack that decisively defeated invaders from the Grimalkin Dominion. For their gallantry, [PAWN_pronoun] and her comrades were personally awarded with the title of Guardian of the Kingdom by the Ratkin King himself.</Ratkin_GuardenerB.baseDescription>
+	<Ratkin_GuardenerB.baseDescription>[PAWN_nameDef] was a Guardener, responsible for tending to the Ratkin Kingdom's gardens and defending them from enemies.\n\n[PAWN_pronoun] fought in the Battle of Whitefur's Keep, where [PAWN_pronoun] was part of the successful counterattack that decisively defeated invaders from the Grimalkin Dominion. For their gallantry, [PAWN_pronoun] and [PAWN_possessive] comrades were personally awarded with the title of Guardian of the Kingdom by the Ratkin King himself.</Ratkin_GuardenerB.baseDescription>
 
 
 	<!-- 기사 -->


### PR DESCRIPTION
## Changes
* Set different full titles for `Ratkin_Guardener` and `Ratkin_GuardenerB` backstories
* Fix mistranslated description for `Ratkin_Guardener` backstory

## Reasoning
@Proxyer pointed out the following problems with my previous PR:
* For `Ratkin_Guardener`, the original Korean and Japanese description states that the Guardener was "accidentally left behind during a mission", but was **_wrongly_** translated into English and Chinese as the Guardener "ran away from his/her post and was exiled as punishment." **This has now been fixed to match the original (lost Guardener) Korean version.** 
* Both `Ratkin_Guardener` and `Ratkin_GuardenerB` have the identical full title of "Ratkin Guardner", which could be confusing. We instead suggested separate, unique full titles:
  * `Ratkin_Guardener.title`: "Ratkin Guardener" --> "Lost Ratkin Guardener"
  * `Ratkin_GuardenerB.title`: "Ratkin Guardener" --> "Guardian of the Kingdom" (An award given by the Ratkin King)
  * Both `Ratkin_Guardener` and `Ratkin_GuardenerB` will **_still_** have the same short title of "Guardener"