### PR TITLE
샷건상향

### DIFF
--- a/Project/1.2/Defs/ThingsDefs/RK_Weapon.xml
+++ b/Project/1.2/Defs/ThingsDefs/RK_Weapon.xml
@@ -1336,9 +1336,9 @@
 		<label>Buck bullet</label>
 		<projectile>
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>5</damageAmountBase>
 			<stoppingPower>2</stoppingPower>
-			<armorPenetrationBase>0.3</armorPenetrationBase>
+			<armorPenetrationBase>0.45</armorPenetrationBase>
 			<speed>75</speed>
 		</projectile>
 		<graphicData>
@@ -1351,8 +1351,8 @@
 		<label>Slug bullet</label>
 		<projectile>
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>35</damageAmountBase>
-			<stoppingPower>4</stoppingPower>
+			<damageAmountBase>25</damageAmountBase>
+			<stoppingPower>3.5</stoppingPower>
 			<armorPenetrationBase>0.6</armorPenetrationBase>
 			<speed>75</speed>
 		</projectile>

--- a/Project/1.2/Defs/ThingsDefs/RK_Weapon.xml
+++ b/Project/1.2/Defs/ThingsDefs/RK_Weapon.xml
@@ -1005,17 +1005,17 @@
 				<accuracyLong>0.50</accuracyLong>
 			</li>
 		</verbs>		
-		<recipeMaker>
-			<researchPrerequisite>PulseTech</researchPrerequisite>
-			<skillRequirements>
-				<Crafting>10</Crafting>
-			</skillRequirements>
+		<recipeMaker Inherit="false">
+			<!-- <researchPrerequisite>PulseTech</researchPrerequisite> -->
+			<!-- <skillRequirements> -->
+			<!-- <Crafting>10</Crafting> -->
+			<!-- </skillRequirements> -->
 		</recipeMaker>
 		<weaponTags Inherit="false">
-			<li>RK_4TierWeapon</li>
+			<!-- <li>RK_4TierWeapon</li> -->
 		</weaponTags>
-		<tradeTags>
-			<li>ExoticMisc</li>
+		<tradeTags Inherit="false">
+			<!-- <li>ExoticMisc</li> -->
 		</tradeTags>
 		<tools>
 			<li>
@@ -1241,12 +1241,12 @@
 			<AccuracyShort>0.85</AccuracyShort>
 			<AccuracyMedium>0.65</AccuracyMedium>
 			<AccuracyLong>0.55</AccuracyLong>
-			<RangedWeapon_Cooldown>1.3</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
 		</statBases>
 		<costList>
-			<WoodLog>20</WoodLog>
-			<Steel>35</Steel>
-			<ComponentIndustrial>2</ComponentIndustrial>
+			<WoodLog>30</WoodLog>
+			<Steel>55</Steel>
+			<ComponentIndustrial>5</ComponentIndustrial>
 		</costList>
 		<recipeMaker>
 			<researchPrerequisite>FlechetteBullet</researchPrerequisite>
@@ -1269,7 +1269,7 @@
 
 				<defaultProjectile>Bullet_RK_Buck</defaultProjectile>
 				<muzzleFlashScale>4</muzzleFlashScale>
-				<warmupTime>1.25</warmupTime>
+				<warmupTime>0.9</warmupTime>
 				<burstShotCount>6</burstShotCount>
 				<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
 				<range>13.9</range>	
@@ -1286,10 +1286,10 @@
 
 				<defaultProjectile>Bullet_RK_Slug</defaultProjectile>
 				<muzzleFlashScale>12</muzzleFlashScale>
-				<warmupTime>1.75</warmupTime>
+				<warmupTime>1.55</warmupTime>
 				<burstShotCount>1</burstShotCount>
 				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-				<range>26.9</range>	
+				<range>27.9</range>
 				<desc>슬러그</desc>
 				<label>Slug fire</label>
 				<texPath>UI/Commands/Slug</texPath>
@@ -1336,9 +1336,9 @@
 		<label>Buck bullet</label>
 		<projectile>
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>3</damageAmountBase>
-			<stoppingPower>1</stoppingPower>
-			<armorPenetrationBase>0.2</armorPenetrationBase>
+			<damageAmountBase>7</damageAmountBase>
+			<stoppingPower>2</stoppingPower>
+			<armorPenetrationBase>0.3</armorPenetrationBase>
 			<speed>75</speed>
 		</projectile>
 		<graphicData>
@@ -1351,9 +1351,9 @@
 		<label>Slug bullet</label>
 		<projectile>
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>18</damageAmountBase>
-			<stoppingPower>2.5</stoppingPower>
-			<armorPenetrationBase>0.35</armorPenetrationBase>
+			<damageAmountBase>35</damageAmountBase>
+			<stoppingPower>4</stoppingPower>
+			<armorPenetrationBase>0.6</armorPenetrationBase>
 			<speed>75</speed>
 		</projectile>
 		<graphicData>

--- a/Project/1.2/Defs/ThingsDefs/RK_Weapon.xml
+++ b/Project/1.2/Defs/ThingsDefs/RK_Weapon.xml
@@ -1005,17 +1005,17 @@
 				<accuracyLong>0.50</accuracyLong>
 			</li>
 		</verbs>		
-		<recipeMaker Inherit="false">
-			<!-- <researchPrerequisite>PulseTech</researchPrerequisite> -->
-			<!-- <skillRequirements> -->
-			<!-- <Crafting>10</Crafting> -->
-			<!-- </skillRequirements> -->
+		<recipeMaker>
+			<researchPrerequisite>PulseTech</researchPrerequisite>
+			<skillRequirements>
+				<Crafting>10</Crafting>
+			</skillRequirements>
 		</recipeMaker>
 		<weaponTags Inherit="false">
-			<!-- <li>RK_4TierWeapon</li> -->
+			<li>RK_4TierWeapon</li>
 		</weaponTags>
-		<tradeTags Inherit="false">
-			<!-- <li>ExoticMisc</li> -->
+		<tradeTags>
+			<li>ExoticMisc</li>
 		</tradeTags>
 		<tools>
 			<li>


### PR DESCRIPTION
샷건
기존보다 성능이 좋아졌기에 생산 비용 증가함.
근접킬존, 근거리 사격킬존용으로 계획됨.

1. 벅탄
전투 산탄총보다는 저지력과 데미지가 낮은 대신에 관통력과 연사력을 높인 형태로 만듦.
데미지가 3에서 7로 소폭 변경된 것으로 보이나, 1회 사격에 6발을 발사하므로 총 데미지가 18에서 42로 상향된 것임.

2. 슬러그탄
펄스라이플의 2점사 사격보다는 발사수와 사거리가 낮지만 데미지와 연사력을 높인 형태로 만듦.

3. 투사체 지정 관통력
데미지 비례가 아닌 임의로 지정된 관통력의 정상 작동 확인됨.
바닐라 전자기 소총으로 테스트함.