### PR TITLE
펄스라이플 연구, 생산, 거래목록 삭제

### DIFF
--- a/Project/1.2/Defs/ResearchDefs/ResearchProjects.xml
+++ b/Project/1.2/Defs/ResearchDefs/ResearchProjects.xml
@@ -110,7 +110,7 @@
 		<researchViewY>1</researchViewY>
 	</ResearchProjectDef>
 	
-	<ResearchProjectDef>
+<!-- 	<ResearchProjectDef>
 		<defName>PulseTech</defName>
 		<label>pulse tech</label>
 		<description>무기와 장비에 펄스 기술을 적용하는 방법을 연구합니다. 연구용 안경이 필요합니다.</description>
@@ -124,7 +124,7 @@
 		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>   
 		<researchViewX>2</researchViewX>
 		<researchViewY>1</researchViewY>
-	</ResearchProjectDef>
+	</ResearchProjectDef> -->
 	
 	<ResearchProjectDef>
 		<defName>RatkinClothing</defName>

--- a/Project/1.2/Defs/ThingsDefs/RK_Weapon.xml
+++ b/Project/1.2/Defs/ThingsDefs/RK_Weapon.xml
@@ -1005,17 +1005,17 @@
 				<accuracyLong>0.50</accuracyLong>
 			</li>
 		</verbs>		
-		<recipeMaker>
-			<researchPrerequisite>PulseTech</researchPrerequisite>
-			<skillRequirements>
-				<Crafting>10</Crafting>
-			</skillRequirements>
+		<recipeMaker Inherit="false">
+			<!-- <researchPrerequisite>PulseTech</researchPrerequisite> -->
+			<!-- <skillRequirements> -->
+			<!-- <Crafting>10</Crafting> -->
+			<!-- </skillRequirements> -->
 		</recipeMaker>
 		<weaponTags Inherit="false">
-			<li>RK_4TierWeapon</li>
+			<!-- <li>RK_4TierWeapon</li> -->
 		</weaponTags>
-		<tradeTags>
-			<li>ExoticMisc</li>
+		<tradeTags Inherit="false">
+			<!-- <li>ExoticMisc</li> -->
 		</tradeTags>
 		<tools>
 			<li>
@@ -1241,12 +1241,12 @@
 			<AccuracyShort>0.85</AccuracyShort>
 			<AccuracyMedium>0.65</AccuracyMedium>
 			<AccuracyLong>0.55</AccuracyLong>
-			<RangedWeapon_Cooldown>1.3</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
 		</statBases>
 		<costList>
-			<WoodLog>20</WoodLog>
-			<Steel>35</Steel>
-			<ComponentIndustrial>2</ComponentIndustrial>
+			<WoodLog>30</WoodLog>
+			<Steel>55</Steel>
+			<ComponentIndustrial>5</ComponentIndustrial>
 		</costList>
 		<recipeMaker>
 			<researchPrerequisite>FlechetteBullet</researchPrerequisite>
@@ -1269,7 +1269,7 @@
 
 				<defaultProjectile>Bullet_RK_Buck</defaultProjectile>
 				<muzzleFlashScale>4</muzzleFlashScale>
-				<warmupTime>1.25</warmupTime>
+				<warmupTime>0.9</warmupTime>
 				<burstShotCount>6</burstShotCount>
 				<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
 				<range>13.9</range>	
@@ -1286,10 +1286,10 @@
 
 				<defaultProjectile>Bullet_RK_Slug</defaultProjectile>
 				<muzzleFlashScale>12</muzzleFlashScale>
-				<warmupTime>1.75</warmupTime>
+				<warmupTime>1.55</warmupTime>
 				<burstShotCount>1</burstShotCount>
 				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-				<range>26.9</range>	
+				<range>27.9</range>
 				<desc>슬러그</desc>
 				<label>Slug fire</label>
 				<texPath>UI/Commands/Slug</texPath>
@@ -1336,9 +1336,9 @@
 		<label>Buck bullet</label>
 		<projectile>
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>3</damageAmountBase>
-			<stoppingPower>1</stoppingPower>
-			<armorPenetrationBase>0.2</armorPenetrationBase>
+			<damageAmountBase>7</damageAmountBase>
+			<stoppingPower>2</stoppingPower>
+			<armorPenetrationBase>0.3</armorPenetrationBase>
 			<speed>75</speed>
 		</projectile>
 		<graphicData>
@@ -1351,9 +1351,9 @@
 		<label>Slug bullet</label>
 		<projectile>
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>18</damageAmountBase>
-			<stoppingPower>2.5</stoppingPower>
-			<armorPenetrationBase>0.35</armorPenetrationBase>
+			<damageAmountBase>35</damageAmountBase>
+			<stoppingPower>4</stoppingPower>
+			<armorPenetrationBase>0.6</armorPenetrationBase>
 			<speed>75</speed>
 		</projectile>
 		<graphicData>

--- a/Project/1.2/Defs/ThingsDefs/RK_Weapon.xml
+++ b/Project/1.2/Defs/ThingsDefs/RK_Weapon.xml
@@ -1241,12 +1241,12 @@
 			<AccuracyShort>0.85</AccuracyShort>
 			<AccuracyMedium>0.65</AccuracyMedium>
 			<AccuracyLong>0.55</AccuracyLong>
-			<RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>1.3</RangedWeapon_Cooldown>
 		</statBases>
 		<costList>
-			<WoodLog>30</WoodLog>
-			<Steel>55</Steel>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<WoodLog>20</WoodLog>
+			<Steel>35</Steel>
+			<ComponentIndustrial>2</ComponentIndustrial>
 		</costList>
 		<recipeMaker>
 			<researchPrerequisite>FlechetteBullet</researchPrerequisite>
@@ -1269,7 +1269,7 @@
 
 				<defaultProjectile>Bullet_RK_Buck</defaultProjectile>
 				<muzzleFlashScale>4</muzzleFlashScale>
-				<warmupTime>0.9</warmupTime>
+				<warmupTime>1.25</warmupTime>
 				<burstShotCount>6</burstShotCount>
 				<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
 				<range>13.9</range>	
@@ -1286,10 +1286,10 @@
 
 				<defaultProjectile>Bullet_RK_Slug</defaultProjectile>
 				<muzzleFlashScale>12</muzzleFlashScale>
-				<warmupTime>1.55</warmupTime>
+				<warmupTime>1.75</warmupTime>
 				<burstShotCount>1</burstShotCount>
 				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-				<range>27.9</range>
+				<range>26.9</range>	
 				<desc>슬러그</desc>
 				<label>Slug fire</label>
 				<texPath>UI/Commands/Slug</texPath>
@@ -1336,9 +1336,9 @@
 		<label>Buck bullet</label>
 		<projectile>
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>7</damageAmountBase>
-			<stoppingPower>2</stoppingPower>
-			<armorPenetrationBase>0.3</armorPenetrationBase>
+			<damageAmountBase>3</damageAmountBase>
+			<stoppingPower>1</stoppingPower>
+			<armorPenetrationBase>0.2</armorPenetrationBase>
 			<speed>75</speed>
 		</projectile>
 		<graphicData>
@@ -1351,9 +1351,9 @@
 		<label>Slug bullet</label>
 		<projectile>
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>35</damageAmountBase>
-			<stoppingPower>4</stoppingPower>
-			<armorPenetrationBase>0.6</armorPenetrationBase>
+			<damageAmountBase>18</damageAmountBase>
+			<stoppingPower>2.5</stoppingPower>
+			<armorPenetrationBase>0.35</armorPenetrationBase>
 			<speed>75</speed>
 		</projectile>
 		<graphicData>


### PR DESCRIPTION
펄스라이플 무기는 생산, 거래목록에서만 삭제이니 오류가 없으나
펄스라이플 연구는 완전 삭제이기에 기존 세이브 첫 로드시 오류가 발생함.
세이브 후 재 로드시엔 오류가 발생하지 않음.
