### PR TITLE
Fix for Wheel Job bug

### DIFF
--- a/Project/1.2/Source/HamsterWheel/JobGiver.cs
+++ b/Project/1.2/Source/HamsterWheel/JobGiver.cs
@@ -45,7 +45,7 @@ namespace NewRatkin
                     {
                         if(wheel.Position.IsInPrisonCell(map))
                         {
-                            if (pawn.CanReserve(wheel) && wheel.GetComp<CompPowerPlantHamsterWheel>().user == null)
+                            if (pawn.CanReserveAndReach(wheel) && wheel.GetComp<CompPowerPlantHamsterWheel>().user == null)
                             {
                                 return new Job(RK_JobDefOf.RK_Job_HamsterWheel, wheel);
                             }

--- a/Project/1.3/Source/HamsterWheel/JobGiver.cs
+++ b/Project/1.3/Source/HamsterWheel/JobGiver.cs
@@ -45,7 +45,7 @@ namespace NewRatkin
                     {
                         if(wheel.Position.IsInPrisonCell(map))
                         {
-                            if (pawn.CanReserve(wheel) && wheel.GetComp<CompPowerPlantHamsterWheel>().user == null)
+                            if (pawn.CanReserveAndReach(wheel) && wheel.GetComp<CompPowerPlantHamsterWheel>().user == null)
                             {
                                 return new Job(RK_JobDefOf.RK_Job_HamsterWheel, wheel);
                             }


### PR DESCRIPTION
When you have a lot of separate rooms with prisoners and wheels, there is a bug: other prisoners can not use their wheel if first or previous founded wheel on the map is not reserved and used. 
With this fix prisoners will choose only reachable wheels to run in.