### PR TITLE
랫킨 드랍전용/습격전용 방어구의 유품태그 삭제

### DIFF
--- a/Project/1.3/Defs/ThingsDefs/RK_Apparel.xml
+++ b/Project/1.3/Defs/ThingsDefs/RK_Apparel.xml
@@ -1729,6 +1729,7 @@
 			<CarryingCapacity>23</CarryingCapacity>
 		</equippedStatOffsets>
 		<apparel>
+			<careIfWornByCorpse>false</careIfWornByCorpse>
 			<bodyPartGroups>
 				<li>Torso</li>
 				<li>Neck</li>
@@ -1798,6 +1799,7 @@
 			<Flammability>-0.1</Flammability>
 		</equippedStatOffsets>
 		<apparel>
+			<careIfWornByCorpse>false</careIfWornByCorpse>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 				<li>Eyes</li>
@@ -1860,6 +1862,7 @@
 			<Flammability>-0.1</Flammability>
 		</equippedStatOffsets>
 		<apparel>
+			<careIfWornByCorpse>false</careIfWornByCorpse>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 				<li>Eyes</li>
@@ -2517,6 +2520,7 @@
 			<SocialImpact>0.15</SocialImpact>
 		</equippedStatOffsets>
 		<apparel>
+			<careIfWornByCorpse>false</careIfWornByCorpse>
 			<bodyPartGroups>
 				<li>Torso</li>
 				<li>Neck</li>


### PR DESCRIPTION
습격 리스크에 따른 보상 목적으로 수정(쿠로요청)