### PR TITLE
랫킨 스타일 오류 수정

### DIFF
--- a/Project/1.3/Defs/CultureDefs/Cultures.xml
+++ b/Project/1.3/Defs/CultureDefs/Cultures.xml
@@ -23,6 +23,16 @@
 		<styleItemTags>
 			<li>
 				<tag>RK_Style</tag>
+				<baseWeight>0</baseWeight>
+				<weightFactor>0</weightFactor>
+			</li>
+			<li>
+				<tag>Urban</tag>
+				<baseWeight>1</baseWeight>
+				<weightFactor>1</weightFactor>
+			</li>
+			<li>
+				<tag>Rural</tag>
 				<baseWeight>1</baseWeight>
 				<weightFactor>1</weightFactor>
 			</li>

--- a/Project/1.3/Patches/Cultures_Patch.xml
+++ b/Project/1.3/Patches/Cultures_Patch.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationAdd">
+		<xpath>/Defs/CultureDef[defName = *]/styleItemTags</xpath>
+		<value>
+			<li>
+				<tag>RK_Style</tag>
+				<baseWeight>0</baseWeight>
+				<weightFactor>0</weightFactor>
+			</li>
+		</value>
+	</Operation>
+</Patch>


### PR DESCRIPTION
랫킨 스타트에 다른 종족이 포함될 경우, 혹은 다른 정착지에 랫킨이 포함될 경우에 '외형변경 요구'가 발생하지만 랫킨 문화, 다른 문화에 변경 가능한 외형이 없기 때문에 플레이어가 '외형변경 요구'를 해결할 수 없는 문제가 발생.
또한 랫킨 스타트, 랫킨 세력에 생성된 타 종족이 랫킨 헤어를 사용하는 경우가 발생함.

우선 RatkiniaTraditionCulture 에서 RK_Style 의 baseWeight, weightFactor 를 0 으로 변경하여 타 종족이 랫킨 스타일을 사용할 수 없도록 변경.
baseWeight, weightFactor 가 0 이더라도 AlienRace.ThingDef_AlienRace 의 styleSettings 에서 RK_Style 가 styleTagsOverride 이기 때문에 랫킨은 RK_Style 를 사용할 수 있음.

그리고 Urban, Rural 를  baseWeight, weightFactor 1 인 상태로 추가하여 랫킨 정착지에 생성, 추가된 인간이 사용할 수 있도록 함.

다음 패치로 RK_Style 를 모든 CultureDef 에 baseWeight, weightFactor 를 0 인 상태로 추가함.
styleTagsOverride 으로 RK_Style 을 사용하게 만들었지만 다른 CultureDef 목록에 없다면 사용할 수 없는 경우가 발생하기 때문에 추가한 것임.
RK_Style 가 이미 있는 CultureDef 에도 중복으로 추가되지만 오류는 발생하지 않음.
( 래비, 냐론 등에서 사용중 )