### PR TITLE
fixed English backstory translation for 1.4

### DIFF
--- a/Project/1.4/Languages/English/DefInjected/BackstoryDef/BackstoryDef.xml
+++ b/Project/1.4/Languages/English/DefInjected/BackstoryDef/BackstoryDef.xml
@@ -1,0 +1,431 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <!-- 들쥐 -->
+
+  <Ratkin_WildChild.title>Ratkin wild born</Ratkin_WildChild.title>
+  <Ratkin_WildChild.titleShort>wild born</Ratkin_WildChild.titleShort>
+  <Ratkin_WildChild.baseDesc>[PAWN_nameDef] grew up in the wild without the benefit of civilization. The wilderness made [PAWN_pronoun], but [PAWN_pronoun] did not receive proper education.</Ratkin_WildChild.baseDesc>
+
+
+  <!-- 땅쥐 -->
+
+  <Ratkin_LandRat.title>Ratkin land rat</Ratkin_LandRat.title>
+  <Ratkin_LandRat.titleShort>land rat</Ratkin_LandRat.titleShort>
+  <Ratkin_LandRat.baseDesc>[PAWN_nameDef] was born in the darkness. After a long period of cave life, [PAWN_pronoun] was skilled at mining, but when many of his compatriots went to the ground, he left them behind.</Ratkin_LandRat.baseDesc>
+
+
+  <!-- 시골아이 -->
+
+  <Ratkin_CountryKid.title>Ratkin country kid</Ratkin_CountryKid.title>
+  <Ratkin_CountryKid.titleShort>country kid</Ratkin_CountryKid.titleShort>
+  <Ratkin_CountryKid.baseDesc>[PAWN_nameDef]'s grandparents were farmers and parents were farmers too. [PAWN_pronoun] grew up with nature and was pure above all else. Until the moment of fate.</Ratkin_CountryKid.baseDesc>
+
+
+  <!-- 꼬마목동 -->
+
+  <Ratkin_ShepherdBoy.title>Ratkin shepherd boy</Ratkin_ShepherdBoy.title>
+  <Ratkin_ShepherdBoy.titleShort>shepherd boy</Ratkin_ShepherdBoy.titleShort>
+  <Ratkin_ShepherdBoy.baseDesc>[PAWN_nameDef]grew up with animals since childhood. [PAWN_pronoun] regards animals as friends.</Ratkin_ShepherdBoy.baseDesc>
+
+
+  <!-- 고아 -->
+
+  <Ratkin_Orphan.title>Ratkin orphan</Ratkin_Orphan.title>
+  <Ratkin_Orphan.titleShort>orphan</Ratkin_Orphan.titleShort>
+  <Ratkin_Orphan.baseDesc>Abandoned, [PAWN_nameDef] grew up without his parents. [PAWN_pronoun] has to live alone, so [PAWN_pronoun] doesn't have any technical knowledge, but he can do various things.</Ratkin_Orphan.baseDesc>
+
+
+  <!-- 학생 -->
+
+  <Ratkin_Student.title>Ratkin student</Ratkin_Student.title>
+  <Ratkin_Student.titleShort>student</Ratkin_Student.titleShort>
+  <Ratkin_Student.baseDesc>[PAWN_nameDef]'s family wasn't wealthy, nor wasn't poor enough to study. [PAWN_pronoun] had a talent for studying but not a workout.</Ratkin_Student.baseDesc>
+
+
+  <!-- 사서자식 -->
+
+  <Ratkin_LittleLibrarian.title>Ratkin little librarian</Ratkin_LittleLibrarian.title>
+  <Ratkin_LittleLibrarian.titleShort>little librarian</Ratkin_LittleLibrarian.titleShort>
+  <Ratkin_LittleLibrarian.baseDesc>[PAWN_nameDef] was a bookworm with [PAWN_nameDef]'s librarian as parents. [PAWN_pronoun] has a wide knowledge,and terrible eye sight too.</Ratkin_LittleLibrarian.baseDesc>
+
+
+  <!-- 금수저 -->
+
+  <Ratkin_GoldenSpoon.title>Ratkin golden spoon</Ratkin_GoldenSpoon.title>
+  <Ratkin_GoldenSpoon.titleShort>golden spoon</Ratkin_GoldenSpoon.titleShort>
+  <Ratkin_GoldenSpoon.baseDesc>[PAWN_nameDef] was born in a whealthy house. [PAWN_pronoun] was surrounded by a variety of artwork but there wasn't much he knew.</Ratkin_GoldenSpoon.baseDesc>
+
+
+  <!-- 서자 -->
+
+  <Ratkin_Bastard.title>Ratkin bastard</Ratkin_Bastard.title>
+  <Ratkin_Bastard.titleShort>bastard</Ratkin_Bastard.titleShort>
+  <Ratkin_Bastard.baseDesc>[PAWN_nameDef] was born as a child of concubine. [PAWN_pronoun] was detected while trying to become inheritor, and became a fugitive.</Ratkin_Bastard.baseDesc>
+
+
+  <!-- 후계자 -->
+
+  <Ratkin_Successor.title>Ratkin successor</Ratkin_Successor.title>
+  <Ratkin_Successor.titleShort>successor</Ratkin_Successor.titleShort>
+  <Ratkin_Successor.baseDesc>[PAWN_nameDef] was born as a heir of noble family. Since the brilliant family tilted, [PAWN_pronoun] had to leave to make it happen.</Ratkin_Successor.baseDesc>
+
+
+  <!-- 정원사지망 -->
+
+  <Ratkin_GuardenerStudent.title>Ratkin Guardener Student</Ratkin_GuardenerStudent.title>
+  <Ratkin_GuardenerStudent.titleShort>Guardener Student</Ratkin_GuardenerStudent.titleShort>
+  <Ratkin_GuardenerStudent.baseDesc>[PAWN_nameDef] went on a path to become a Guardener. Only the best will be able to take care of enemy and the garden.</Ratkin_GuardenerStudent.baseDesc>
+
+
+  <!-- 쉐프지망생 -->
+
+  <Ratkin_ChefStudent.title>Ratkin Chef Student</Ratkin_ChefStudent.title>
+  <Ratkin_ChefStudent.titleShort>Chef Student</Ratkin_ChefStudent.titleShort>
+  <Ratkin_ChefStudent.baseDesc>[PAWN_nameDef] started cooking because liked eating things. For [PAWN_pronoun], food is an enjoyment of life, so leaved for an adventure to eat more delicious food.</Ratkin_ChefStudent.baseDesc>
+
+
+  <!-- 집시아이 -->
+
+  <Ratkin_RomanyKid.title>Ratkin Romany Kid</Ratkin_RomanyKid.title>
+  <Ratkin_RomanyKid.titleShort>Romany Kid</Ratkin_RomanyKid.titleShort>
+  <Ratkin_RomanyKid.baseDesc>[PAWN_nameDef] wandered around aimlessly from place to place. [PAWN_pronoun] is versatile, but a wandering life seems to be not enough to have a deep relationship with people.</Ratkin_RomanyKid.baseDesc>
+
+
+  <!-- 장교의 아이 -->
+
+  <Ratkin_OfficerChild.title>Ratkin Officer Child</Ratkin_OfficerChild.title>
+  <Ratkin_OfficerChild.titleShort>Officer Child</Ratkin_OfficerChild.titleShort>
+  <Ratkin_OfficerChild.baseDesc>[PAWN_nameDef] was born as a child of commissioned officer. The shooting skill and charisma that he learned from his parents since his childhood made [PAWN_pronoun] to be a timber of officer, but also made him haughty.</Ratkin_OfficerChild.baseDesc>
+
+
+  <!-- 상인아이 -->
+
+  <Ratkin_MerchantKid.title>Ratkin Merchant Kid</Ratkin_MerchantKid.title>
+  <Ratkin_MerchantKid.titleShort>Merchant Kid</Ratkin_MerchantKid.titleShort>
+  <Ratkin_MerchantKid.baseDesc>[PAWN_nameDef] was born as a child of merchandiser. [PAWN_pronoun] knows how to make money by learning business over parents shoulder.</Ratkin_MerchantKid.baseDesc>
+
+
+  <!-- 일반아이 -->
+
+  <Ratkin_Kid.title>Ratkin Kid</Ratkin_Kid.title>
+  <Ratkin_Kid.titleShort>Kid</Ratkin_Kid.titleShort>
+  <Ratkin_Kid.baseDesc>[PAWN_nameDef] is just a kid. learned many things what parents do over shoulder in ordinary family. But couldn't build professional knowledge because didn't have chance to get higher education.</Ratkin_Kid.baseDesc>
+
+
+  <!-- 하인자식 -->
+
+  <Ratkin_ServentChild.title>Ratkin Servent Child</Ratkin_ServentChild.title>
+  <Ratkin_ServentChild.titleShort>Servent Child</Ratkin_ServentChild.titleShort>
+  <Ratkin_ServentChild.baseDesc>[PAWN_nameDef] was born as a child of servant. By law, [PAWN_pronoun] is also destined to become a servant, but he ran away to change his destiny.</Ratkin_ServentChild.baseDesc>
+
+
+  <!-- 인간조수 -->
+
+  <Ratkin_HumanAssistant.title>Ratkin Human Assistant</Ratkin_HumanAssistant.title>
+  <Ratkin_HumanAssistant.titleShort>Human Assistant</Ratkin_HumanAssistant.titleShort>
+  <Ratkin_HumanAssistant.baseDesc>[PAWN_nameDef] helped small things since child as a human assistant. But when the owner died in an accident, [PAWN_pronoun] hit the road to find his own life.</Ratkin_HumanAssistant.baseDesc>
+
+
+  <!-- 도시쥐자식 -->
+
+  <Ratkin_CityKid.title>Ratkin City Kid</Ratkin_CityKid.title>
+  <Ratkin_CityKid.titleShort>City Kid</Ratkin_CityKid.titleShort>
+  <Ratkin_CityKid.baseDesc>[PAWN_nameDef] was born in city. [PAWN_pronoun] was exposed to the civilization of the city, so could understand culture easily unlike other Ratkins.</Ratkin_CityKid.baseDesc>
+
+
+  <!-- 노예 -->
+
+  <Ratkin_SlaveKid.title>Ratkin Slave Kid</Ratkin_SlaveKid.title>
+  <Ratkin_SlaveKid.titleShort>Slave Kid</Ratkin_SlaveKid.titleShort>
+  <Ratkin_SlaveKid.baseDesc>[PAWN_nameDef] do not know how got here, but had a slave-mark. [PAWN_pronoun] ran away for freedom because couldn't bear all the chores.</Ratkin_SlaveKid.baseDesc>
+
+
+  <!-- 실험실쥐 -->
+
+  <Ratkin_LaboratoryRats.title>Ratkin Specimen</Ratkin_LaboratoryRats.title>
+  <Ratkin_LaboratoryRats.titleShort>Ratkin Specimen</Ratkin_LaboratoryRats.titleShort>
+  <Ratkin_LaboratoryRats.baseDesc>[PAWN_nameDef] was born in the humans lab. One day, [PAWN_pronoun], genetically manipulated as a military rat, felt a deep desire for freedom. so, ran away from the humans lab.</Ratkin_LaboratoryRats.baseDesc>
+
+
+  <!-- 좀도둑 -->
+
+  <Ratkin_PettyTheft.title>Ratkin Petty Theft</Ratkin_PettyTheft.title>
+  <Ratkin_PettyTheft.titleShort>Petty Theft</Ratkin_PettyTheft.titleShort>
+  <Ratkin_PettyTheft.baseDesc>For [PAWN_nameDef], stealing was just borrowing for a while. [PAWN_pronoun]'s frequent stealing was eventually caught and while being taken as a slave, could have escaped barely because of attack.</Ratkin_PettyTheft.baseDesc>
+
+
+  <!-- 캐러반상인 -->
+
+  <Ratkin_CaravanMerchant.title>Ratkin Caravan Merchant</Ratkin_CaravanMerchant.title>
+  <Ratkin_CaravanMerchant.titleShort>Caravan Merchant</Ratkin_CaravanMerchant.titleShort>
+  <Ratkin_CaravanMerchant.baseDesc>[PAWN_nameDef] is a merchandiser who leads merchants and living a nomadic life. But after being attacked and losing everything, [PAWN_pronoun] decided to live a new life.</Ratkin_CaravanMerchant.baseDesc>
+
+
+  <!-- 방랑자 -->
+
+  <Ratkin_Wanderer.title>Ratkin Wanderer</Ratkin_Wanderer.title>
+  <Ratkin_Wanderer.titleShort>Wanderer</Ratkin_Wanderer.titleShort>
+  <Ratkin_Wanderer.baseDesc>[PAWN_nameDef] is just a wanderer who lives aimless wandering life. For [PAWN_pronoun], life with gardening is just a specious dream.</Ratkin_Wanderer.baseDesc>
+
+
+  <!-- 농부 -->
+
+  <Ratkin_Farmer.title>Ratkin Farmer</Ratkin_Farmer.title>
+  <Ratkin_Farmer.titleShort>Farmer</Ratkin_Farmer.titleShort>
+  <Ratkin_Farmer.baseDesc>[PAWN_nameDef] is a farmer. [PAWN_pronoun] became a farmer by taking over the parents family business and [PAWN_pronoun]'s kids will be farmer too.</Ratkin_Farmer.baseDesc>
+
+
+  <!-- 광부 -->
+
+  <Ratkin_Miner.title>Ratkin Miner</Ratkin_Miner.title>
+  <Ratkin_Miner.titleShort>Miner</Ratkin_Miner.titleShort>
+  <Ratkin_Miner.baseDesc>[PAWN_nameDef] had strength in digging, so became a miner. For [PAWN_pronoun], digging ground was a piece of cake, but used to think of running away from this narrow and stuffy place.</Ratkin_Miner.baseDesc>
+
+
+  <!-- 사냥꾼 -->
+
+  <Ratkin_Hunter.title>Ratkin Hunter</Ratkin_Hunter.title>
+  <Ratkin_Hunter.titleShort>Hunter</Ratkin_Hunter.titleShort>
+  <Ratkin_Hunter.baseDesc>[PAWN_nameDef] is a hunter who hunts animals. Unlike the other ratkins, [PAWN_pronoun] had good eyesight so could see animals moving from far away.</Ratkin_Hunter.baseDesc>
+
+
+  <!-- 목동 -->
+
+  <Ratkin_Shepherd.title>Ratkin Shepherd</Ratkin_Shepherd.title>
+  <Ratkin_Shepherd.titleShort>Shepherd</Ratkin_Shepherd.titleShort>
+  <Ratkin_Shepherd.baseDesc>[PAWN_nameDef] runs a farm. [PAWN_pronoun] used to have many livestock, but because of polluted ship crash it's just a past thing now.</Ratkin_Shepherd.baseDesc>
+
+
+  <!-- 시민 -->
+
+  <Ratkin_Civil.title>Ratkin Civil</Ratkin_Civil.title>
+  <Ratkin_Civil.titleShort>Civil</Ratkin_Civil.titleShort>
+  <Ratkin_Civil.baseDesc>[PAWN_nameDef] is a citizen of the ratkin kingdom. [PAWN_pronoun] have been leading life with menial tasks inside the kingdom.</Ratkin_Civil.baseDesc>
+
+
+  <!-- 귀족 -->
+
+  <Ratkin_Noble.title>Ratkin Noble</Ratkin_Noble.title>
+  <Ratkin_Noble.titleShort>Noble</Ratkin_Noble.titleShort>
+  <Ratkin_Noble.baseDesc>[PAWN_nameDef] is noble of the ratkin kingdom. But [PAWN_pronoun], who was forced to go into exile due to the political issues, started wandering life to get back.</Ratkin_Noble.baseDesc>
+
+
+  <!-- 도시상인 -->
+
+  <Ratkin_CityMerchant.title>Ratkin City Merchant</Ratkin_CityMerchant.title>
+  <Ratkin_CityMerchant.titleShort>City Merchant</Ratkin_CityMerchant.titleShort>
+  <Ratkin_CityMerchant.baseDesc>[PAWN_nameDef] is a city merchandiser. [PAWN_pronoun] used to sell many kind of things due to the good dexterity.</Ratkin_CityMerchant.baseDesc>
+
+
+  <!-- 사서 -->
+
+  <Ratkin_Librarian.title>Ratkin Librarian</Ratkin_Librarian.title>
+  <Ratkin_Librarian.titleShort>Librarian</Ratkin_Librarian.titleShort>
+  <Ratkin_Librarian.baseDesc>[PAWN_nameDef] is a librarian who protects the library. [PAWN_pronoun] has a lot of academic knowledge, but life with the book seems long enough to forget how to dig.</Ratkin_Librarian.baseDesc>
+
+
+  <!-- 정원사 -->
+
+  <Ratkin_Guardener.title>Ratkin Guardener</Ratkin_Guardener.title>
+  <Ratkin_Guardener.titleShort>Guardener</Ratkin_Guardener.titleShort>
+  <Ratkin_Guardener.baseDesc>[PAWN_nameDef] is a senior Guardener.But during [PAWN_pronoun] assignment [PAWN_pronoun] fell alone. [PAWN_pronoun] want to find a way to go back to the kingdom.</Ratkin_Guardener.baseDesc>
+
+
+  <!-- 기사 -->
+
+  <Ratkin_Knight.title>Ratkin Knight</Ratkin_Knight.title>
+  <Ratkin_Knight.titleShort>knight</Ratkin_Knight.titleShort>
+  <Ratkin_Knight.baseDesc>[PAWN_nameDef] is knight of Ratkinia. They are the strong buttresses of the kingdom.</Ratkin_Knight.baseDesc>
+
+
+  <!-- 기사단장 -->
+
+  <Ratkin_KnightCommander.title>Ratkin Knight commander</Ratkin_KnightCommander.title>
+  <Ratkin_KnightCommander.titleShort>commander</Ratkin_KnightCommander.titleShort>
+  <Ratkin_KnightCommander.baseDesc>[PAWN_nameDef]is the chosen knight of the Ratkin Kingdom. In accordance with the tradition of knights, the master of knighthood will be chosen from among those from the countryside.</Ratkin_KnightCommander.baseDesc>
+
+
+  <!-- 교사 -->
+
+  <Ratkin_Teacher.title>Ratkin Teacher</Ratkin_Teacher.title>
+  <Ratkin_Teacher.titleShort>Teacher</Ratkin_Teacher.titleShort>
+  <Ratkin_Teacher.baseDesc>[PAWN_nameDef] is a teacher who teaches kids. But there was nothing [PAWN_pronoun] could do in a rural village where all the kids had left, so had to go out looking for new home where the beginning is.</Ratkin_Teacher.baseDesc>
+
+
+  <!-- 대장장이 -->
+
+  <Ratkin_Blacksmith.title>Ratkin Blacksmith</Ratkin_Blacksmith.title>
+  <Ratkin_Blacksmith.titleShort>Blacksmith</Ratkin_Blacksmith.titleShort>
+  <Ratkin_Blacksmith.baseDesc>[PAWN_nameDef] is a blacksmith who makes weapons or tools. [PAWN_pronoun] went on an adventure to search for stronger materials.</Ratkin_Blacksmith.baseDesc>
+
+
+  <!-- 도둑 -->
+
+  <Ratkin_Thief.title>Ratkin Thief</Ratkin_Thief.title>
+  <Ratkin_Thief.titleShort>Thief</Ratkin_Thief.titleShort>
+  <Ratkin_Thief.baseDesc>[PAWN_nameDef] is sustaining life with stealing day by day. [PAWN_pronoun] repeated leaving to another city when face is known in the city.</Ratkin_Thief.baseDesc>
+
+
+  <!-- 외교관 -->
+
+  <Ratkin_Ambassador.title>Ratkin Ambassador</Ratkin_Ambassador.title>
+  <Ratkin_Ambassador.titleShort>Ambassador</Ratkin_Ambassador.titleShort>
+  <Ratkin_Ambassador.baseDesc>[PAWN_nameDef] is ratkin kingdom's diplomat. Due to diplomatic problems, [PAWN_pronoun] is temporarily exiled as an asylum status.</Ratkin_Ambassador.baseDesc>
+
+
+  <!-- 군인 -->
+
+  <Ratkin_Soldier.title>Ratkin Soldier</Ratkin_Soldier.title>
+  <Ratkin_Soldier.titleShort>Soldier</Ratkin_Soldier.titleShort>
+  <Ratkin_Soldier.baseDesc>[PAWN_nameDef] is a soldier of human city. [PAWN_pronoun] is a soldier who has trained between humans and mastered different battle methods then other ratkins. But was abandoned during a mission, and decided to find a new life.</Ratkin_Soldier.baseDesc>
+
+
+  <!-- 탐험가 -->
+
+  <Ratkin_Explorer.title>Ratkin Explorer</Ratkin_Explorer.title>
+  <Ratkin_Explorer.titleShort>Explorer</Ratkin_Explorer.titleShort>
+  <Ratkin_Explorer.baseDesc>[PAWN_nameDef] was full of curiousity about the world. [PAWN_pronoun] won't stop until explore all of these planetary system.</Ratkin_Explorer.baseDesc>
+
+
+  <!-- 요리사 -->
+
+  <Ratkin_Chef.title>Ratkin Chef</Ratkin_Chef.title>
+  <Ratkin_Chef.titleShort>Chef</Ratkin_Chef.titleShort>
+  <Ratkin_Chef.baseDesc>[PAWN_nameDef] is a chef who has the desire to cook everything in the world. [PAWN_pronoun] has left on the way to find the best nuts among them.</Ratkin_Chef.baseDesc>
+
+
+  <!-- 시녀 -->
+
+  <Ratkin_HandMaiden.title>Ratkin HandMaiden</Ratkin_HandMaiden.title>
+  <Ratkin_HandMaiden.titleShort>HandMaiden</Ratkin_HandMaiden.titleShort>
+  <Ratkin_HandMaiden.baseDesc>[PAWN_nameDef] is maid of nobility who is doing from their simple works to their eyes and ears.</Ratkin_HandMaiden.baseDesc>
+
+
+  <!-- 사수 -->
+
+  <Ratkin_Shooter.title>Ratkin Shooter</Ratkin_Shooter.title>
+  <Ratkin_Shooter.titleShort>Shooter</Ratkin_Shooter.titleShort>
+  <Ratkin_Shooter.baseDesc>[PAWN_nameDef] had good eyesight as a ratkin. [PAWN_pronoun] volunteered for the military by using strong point, and thanks to that became a best shooter.</Ratkin_Shooter.baseDesc>
+
+
+  <!-- 의사 -->
+
+  <Ratkin_Doctor.title>Ratkin Doctor</Ratkin_Doctor.title>
+  <Ratkin_Doctor.titleShort>Doctor</Ratkin_Doctor.titleShort>
+  <Ratkin_Doctor.baseDesc>[PAWN_nameDef] was a doctor of the kingdom, but banished to the outskirts because could not saved the nobility. [PAWN_pronoun] went from place to place trying to sharpen medical skills to prove he wasn't wrong.</Ratkin_Doctor.baseDesc>
+
+
+  <!-- 의무관 -->
+
+  <Ratkin_ArmySurgeon.title>Ratkin Army Surgeon</Ratkin_ArmySurgeon.title>
+  <Ratkin_ArmySurgeon.titleShort>Army Surgeon</Ratkin_ArmySurgeon.titleShort>
+  <Ratkin_ArmySurgeon.baseDesc>[PAWN_nameDef] was a doctor who saves ratkins in the field of battle. even if they were a small life, [PAWN_pronoun] volunteered up to a sense of kinship and mission, but left the fact that nothing would change.</Ratkin_ArmySurgeon.baseDesc>
+
+
+  <!-- 건축가 -->
+
+  <Ratkin_ConstructionWorker.title>Ratkin Construction Worker</Ratkin_ConstructionWorker.title>
+  <Ratkin_ConstructionWorker.titleShort>Construction Worker</Ratkin_ConstructionWorker.titleShort>
+  <Ratkin_ConstructionWorker.baseDesc>[PAWN_nameDef] is a laborer working in the construction site. [PAWN_pronoun] mainly been working on building underground tunnels.</Ratkin_ConstructionWorker.baseDesc>
+
+
+  <!-- 부자 -->
+
+  <Ratkin_Rich.title>Ratkin Rich</Ratkin_Rich.title>
+  <Ratkin_Rich.titleShort>Rich</Ratkin_Rich.titleShort>
+  <Ratkin_Rich.baseDesc>[PAWN_nameDef] had a great talent for cheating people into making money. But soon it was revealed and [PAWN_pronoun] had no choice but to run away.</Ratkin_Rich.baseDesc>
+
+
+  <!-- 수녀 -->
+
+  <Ratkin_Sister.title>Ratkin Sister</Ratkin_Sister.title>
+  <Ratkin_Sister.titleShort>Sister</Ratkin_Sister.titleShort>
+  <Ratkin_Sister.baseDesc>[PAWN_nameDef] as a nun, have been taking care of ancestral rites or religious affairs in the ratkin society. [PAWN_pronoun] was attacked while traveling far away for a religious event and was barely able to escape. escape.</Ratkin_Sister.baseDesc>
+
+
+  <!-- 도축업자 -->
+
+  <Ratkin_Butcher.title>Ratkin Butcher</Ratkin_Butcher.title>
+  <Ratkin_Butcher.titleShort>Butcher</Ratkin_Butcher.titleShort>
+  <Ratkin_Butcher.baseDesc>[PAWN_nameDef] is a trader who butchery animals and sell.</Ratkin_Butcher.baseDesc>
+
+
+  <!-- 도시메이드 -->
+
+  <Ratkin_CityMaid.title>Ratkin City Maid</Ratkin_CityMaid.title>
+  <Ratkin_CityMaid.titleShort>City Maid</Ratkin_CityMaid.titleShort>
+  <Ratkin_CityMaid.baseDesc>[PAWN_nameDef] is a housekeeper who helps housework in the city. Humans usually selected handsome ratkins as a housekeeper and [PAWN_pronoun] was one of them. </Ratkin_CityMaid.baseDesc>
+
+
+  <!-- 아이돌 -->
+
+  <Ratkin_Idol.title>Ratkin Idol</Ratkin_Idol.title>
+  <Ratkin_Idol.titleShort>Idol</Ratkin_Idol.titleShort>
+  <Ratkin_Idol.baseDesc>[PAWN_nameDef] have been doing entertainment activity as an idol. Unfortunately, [PAWN_pronoun]'s car overturned and he opened eyes in an unknown location.</Ratkin_Idol.baseDesc>
+
+
+  <!-- 연쇄살인마 -->
+
+  <Ratkin_Murderer.title>Ratkin Murderer</Ratkin_Murderer.title>
+  <Ratkin_Murderer.titleShort>Murderer</Ratkin_Murderer.titleShort>
+  <Ratkin_Murderer.baseDesc>[PAWN_nameDef] is a ratkin who got crazy in the city. [PAWN_pronoun] kept enjoying murder by using small body to quickly escape from the crime site.</Ratkin_Murderer.baseDesc>
+
+
+  <!-- 인간조수 -->
+
+  <Ratkin_Assistant.title>Ratkin Assistant</Ratkin_Assistant.title>
+  <Ratkin_Assistant.titleShort>Assistant</Ratkin_Assistant.titleShort>
+  <Ratkin_Assistant.baseDesc>As a researcher, [PAWN_nameDef] helped with various works from human's small studies to big ones. [PAWN_pronoun] learned those studies over shoulder at every opportunity.</Ratkin_Assistant.baseDesc>
+
+
+  <!-- 과학자 -->
+
+  <Ratkin_Scientist.title>Ratkin Scientist</Ratkin_Scientist.title>
+  <Ratkin_Scientist.titleShort>Scientist</Ratkin_Scientist.titleShort>
+  <Ratkin_Scientist.baseDesc>As a scientist, [PAWN_nameDef] have been studying science among humans. But too much concentrating in studies, [PAWN_pronoun] became physically weak and also eyesight got worse.</Ratkin_Scientist.baseDesc>
+
+
+  <!-- 공학자 -->
+
+  <Ratkin_Engineer.title>Ratkin Engineer</Ratkin_Engineer.title>
+  <Ratkin_Engineer.titleShort>Engineer</Ratkin_Engineer.titleShort>
+  <Ratkin_Engineer.baseDesc>[PAWN_nameDef] is a engineer who used to make precision parts. [PAWN_pronoun] used his talent to make mechanoid but didn't know it would become a source of trouble.</Ratkin_Engineer.baseDesc>
+
+
+  <!-- 농학가 -->
+
+  <Ratkin_Agriculturist.title>Ratkin Agriculturist</Ratkin_Agriculturist.title>
+  <Ratkin_Agriculturist.titleShort>Agriculturist</Ratkin_Agriculturist.titleShort>
+  <Ratkin_Agriculturist.baseDesc>[PAWN_nameDef] is a agronomist who came out to the city to develop the agricultural system of ratkin. [PAWN_pronoun] is dreaming of going back to the hometown one day, and develop agricultural system.</Ratkin_Agriculturist.baseDesc>
+
+
+  <!-- 랫킨헌터 -->
+
+  <Ratkin_RatkinHunter.title>RatkinHunter</Ratkin_RatkinHunter.title>
+  <Ratkin_RatkinHunter.titleShort>RatkinHunter</Ratkin_RatkinHunter.titleShort>
+  <Ratkin_RatkinHunter.baseDesc>[PAWN_nameDef] is a hunter who catches escaped ratkin. But one day, [PAWN_pronoun] left with a sense of skepticism about his job when he saw the young fugitive ratkin.</Ratkin_RatkinHunter.baseDesc>
+
+
+  <!-- 실험체 -->
+
+  <Ratkin_Subject.title>Ratkin Subject</Ratkin_Subject.title>
+  <Ratkin_Subject.titleShort>Subject</Ratkin_Subject.titleShort>
+  <Ratkin_Subject.baseDesc>[PAWN_nameDef] is a ratkin subject of experiment. [PAWN_pronoun] been reinforced by a number of experiments, but accident happened during the experiment and could barely escaped.</Ratkin_Subject.baseDesc>
+
+
+  <!-- 방랑자 -->
+
+  <Ratkin_Vagabond.title>Ratkin Vagabond</Ratkin_Vagabond.title>
+  <Ratkin_Vagabond.titleShort>Vagabond</Ratkin_Vagabond.titleShort>
+  <Ratkin_Vagabond.baseDesc>[PAWN_nameDef] have been doing a aimless wandering life. [PAWN_pronoun]'s past is not known exactly, but wisdom gained from wandering life seems to be reliable enough.</Ratkin_Vagabond.baseDesc>
+
+
+  <!-- 데모맨 -->
+
+  <Ratkin_Demoman.title>Ratkin Demoman</Ratkin_Demoman.title>
+  <Ratkin_Demoman.titleShort>Demoman</Ratkin_Demoman.titleShort>
+  <Ratkin_Demoman.baseDesc>Unlike other rats, [PAWN_nameDef] is obsessed with explosions. Ratskin's commandos isolate these dangerous classes and put them on dangerous missions.</Ratkin_Demoman.baseDesc>
+
+
+</LanguageData>


### PR DESCRIPTION
Just copied the existing translation from `Languages/English` and renamed the keys.